### PR TITLE
add llm_ocr_demo.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ may base your implementation off of `naive.py`.
 
 See https://github.com/MLDSAI/puterbot/issues for ideas on where to start.
 
+See `strategies/llm_ocr_demo.py` for example usage of a Large Language Model
+and Optical Character Recognition.
+
 ### Evaluation Criteria
 
 Your submission will be evaluated based on the following criteria: 

--- a/puterbot/replay.py
+++ b/puterbot/replay.py
@@ -30,9 +30,14 @@ def replay(
 
     strategy_class_by_name = get_strategy_class_by_name()
     if strategy_name not in strategy_class_by_name:
-        available_strategy_names = ", ".join(strategy_class_by_name.keys())
+        strategy_names = [
+            name
+            for name in strategy_class_by_name.keys()
+            if not name.lower().endswith("mixin")
+        ]
+        available_strategies = ", ".join(strategy_names)
         raise ValueError(
-            f"Invalid {strategy_name=}; {available_strategy_names=}"
+            f"Invalid {strategy_name=}; {available_strategies=}"
         )
 
     strategy_class = strategy_class_by_name[strategy_name]

--- a/puterbot/replay.py
+++ b/puterbot/replay.py
@@ -1,18 +1,8 @@
-from pprint import pformat
-import importlib
-import time
-
 from loguru import logger
-from pynput import keyboard, mouse
 import fire
 
-from puterbot.crud import (
-    get_latest_recording,
-)
-from puterbot.utils import (
-    configure_logging,
-    get_strategy_class_by_name,
-)
+from puterbot.crud import get_latest_recording
+from puterbot.utils import configure_logging, get_strategy_class_by_name
 
 
 LOG_LEVEL = "INFO"

--- a/puterbot/strategies/__init__.py
+++ b/puterbot/strategies/__init__.py
@@ -1,3 +1,4 @@
 from puterbot.strategies.base import BaseReplayStrategy
 from puterbot.strategies.naive import NaiveReplayStrategy
+from puterbot.strategies.llm_ocr_demo import LLMOCRDemoReplayStrategy
 # add more strategies here

--- a/puterbot/strategies/base.py
+++ b/puterbot/strategies/base.py
@@ -61,8 +61,9 @@ class BaseReplayStrategy(ABC):
         t = time.time()
         self.frame_times.append(t)
         dts = np.diff(self.frame_times)
-        mean_dt = np.mean(dts)
-        fps = len(dts) / mean_dt
-        logger.info(f"{fps=:.2f}")
+        if len(dts) > 1:
+            mean_dt = np.mean(dts)
+            fps = len(dts) / mean_dt
+            logger.info(f"{fps=:.2f}")
         if len(self.frame_times) > self.max_frame_times:
             self.frame_times.pop(0)

--- a/puterbot/strategies/base.py
+++ b/puterbot/strategies/base.py
@@ -3,13 +3,19 @@ Implements the base class for implementing replay strategies.
 """
 
 from abc import ABC, abstractmethod
+import time
 
+from loguru import logger
 from pynput import keyboard, mouse
 import mss.base
+import numpy as np
 
 from puterbot.models import Recording, InputEvent
 from puterbot.playback import play_input_event
 from puterbot.utils import get_screenshot
+
+
+MAX_FRAME_TIMES = 1000
 
 
 class BaseReplayStrategy(ABC):
@@ -17,10 +23,13 @@ class BaseReplayStrategy(ABC):
     def __init__(
         self,
         recording: Recording,
+        max_frame_times: int = MAX_FRAME_TIMES,
     ):
         self.recording = recording
+        self.max_frame_times = max_frame_times
         self.input_events = []
         self.screenshots = []
+        self.frame_times = []
 
     @abstractmethod
     def get_next_input_event(
@@ -29,9 +38,7 @@ class BaseReplayStrategy(ABC):
     ) -> InputEvent:
         pass
 
-    def run(
-        self,
-    ):
+    def run(self):
         keyboard_controller = keyboard.Controller()
         mouse_controller = mouse.Controller()
         while True:
@@ -41,6 +48,7 @@ class BaseReplayStrategy(ABC):
                 input_event = self.get_next_input_event(screenshot)
             except StopIteration:
                 break
+            self.log_fps()
             self.input_events.append(input_event)
             if input_event:
                 play_input_event(
@@ -48,3 +56,13 @@ class BaseReplayStrategy(ABC):
                     mouse_controller,
                     keyboard_controller,
                 )
+
+    def log_fps(self):
+        t = time.time()
+        self.frame_times.append(t)
+        dts = np.diff(self.frame_times)
+        mean_dt = np.mean(dts)
+        fps = len(dts) / mean_dt
+        logger.info(f"{fps=:.2f}")
+        if len(self.frame_times) > self.max_frame_times:
+            self.frame_times.pop(0)

--- a/puterbot/strategies/llm_mixin.py
+++ b/puterbot/strategies/llm_mixin.py
@@ -1,0 +1,56 @@
+"""
+Implements a ReplayStrategy mixin for generating LLM completions.
+"""
+
+
+from loguru import logger
+import transformers as tf  # RIP TensorFlow
+
+from puterbot.models import Recording
+from puterbot.strategies.base import BaseReplayStrategy
+
+
+MODEL_NAME = "gpt2-xl"  # gpt2-xl
+MODEL_MAX_LENGTH = 1024
+
+
+class LLMReplayStrategyMixin(BaseReplayStrategy):
+
+    def __init__(
+        self,
+        recording: Recording,
+        model_name=MODEL_NAME,
+    ):
+        super().__init__(recording)
+
+        logger.info(f"{model_name=}")
+        self.tokenizer = tf.AutoTokenizer.from_pretrained(model_name)
+        self.model = tf.AutoModelForCausalLM.from_pretrained(model_name)
+
+    def generate_completion(self, prompt, max_tokens):
+        if MODEL_MAX_LENGTH and len(prompt) > MODEL_MAX_LENGTH:
+            logger.warning(
+                f"Truncating from {len(prompt)=} to {MODEL_MAX_LENGTH=}"
+            )
+            prompt = prompt[:MODEL_MAX_LENGTH]
+        logger.info(f"{prompt=} {max_tokens=}")
+        input_tokens = self.tokenizer(prompt, return_tensors="pt")
+        pad_token_id = self.tokenizer.eos_token_id
+        attention_mask = input_tokens["attention_mask"]
+
+        output_tokens = self.model.generate(
+            input_ids=input_tokens["input_ids"],
+            attention_mask=attention_mask,
+            max_length=input_tokens["input_ids"].shape[-1] + max_tokens,
+            pad_token_id=pad_token_id,
+            num_return_sequences=1
+        )
+
+        N = input_tokens["input_ids"].shape[-1]
+        completion = self.tokenizer.decode(
+            output_tokens[:, N:][0],
+            clean_up_tokenization_spaces=True,
+        )
+        logger.info(f"{completion=}")
+
+        return completion

--- a/puterbot/strategies/llm_mixin.py
+++ b/puterbot/strategies/llm_mixin.py
@@ -15,7 +15,7 @@ from puterbot.models import Recording
 from puterbot.strategies.base import BaseReplayStrategy
 
 
-MODEL_NAME = "gpt2-xl"  # gpt2 is smaller and faster
+MODEL_NAME = "gpt2"  # gpt2-xl is bigger and slower
 MODEL_MAX_LENGTH = 1024
 
 

--- a/puterbot/strategies/llm_ocr_demo.py
+++ b/puterbot/strategies/llm_ocr_demo.py
@@ -1,5 +1,9 @@
 """
-Implements a ReplayStrategy mixin for generating LLM completions.
+Demonstration of LLMReplayStrategyMixin and OCRReplayStrategyMixin.
+
+Usage:
+
+    $ python puterbot/replay.py LLMOCRDemoReplayStrategy
 """
 
 

--- a/puterbot/strategies/llm_ocr_demo.py
+++ b/puterbot/strategies/llm_ocr_demo.py
@@ -1,0 +1,38 @@
+"""
+Implements a ReplayStrategy mixin for generating LLM completions.
+"""
+
+
+from loguru import logger
+
+import mss.base
+
+from puterbot.events import get_events
+from puterbot.models import Recording
+from puterbot.strategies.base import BaseReplayStrategy
+from puterbot.strategies.llm_mixin import LLMReplayStrategyMixin
+from puterbot.strategies.ocr_mixin import OCRReplayStrategyMixin
+
+
+class LLMOCRDemoReplayStrategy(
+    LLMReplayStrategyMixin,
+    OCRReplayStrategyMixin,
+    BaseReplayStrategy,
+):
+
+    def __init__(
+        self,
+        recording: Recording,
+    ):
+        super().__init__(recording)
+
+    def get_next_input_event(
+        self,
+        screenshot: mss.base.ScreenShot,
+    ):
+        text = self.get_text(screenshot)
+
+        # this doesn't make sense and is for demonstrative purposes only
+        completion = self.generate_completion(text, 100)
+
+        return None

--- a/puterbot/strategies/llm_ocr_demo.py
+++ b/puterbot/strategies/llm_ocr_demo.py
@@ -7,8 +7,6 @@ Usage:
 """
 
 
-from loguru import logger
-
 import mss.base
 
 from puterbot.events import get_events
@@ -36,7 +34,7 @@ class LLMOCRDemoReplayStrategy(
     ):
         text = self.get_text(screenshot)
 
-        # this doesn't make sense and is for demonstrative purposes only
+        # N.B. this doesn't make sense and is for demonstration purposes only
         completion = self.generate_completion(text, 100)
 
         return None

--- a/puterbot/strategies/naive.py
+++ b/puterbot/strategies/naive.py
@@ -9,13 +9,8 @@ import time
 from loguru import logger
 import mss.base
 
-from puterbot.events import (
-    get_events,
-)
-from puterbot.utils import (
-    display_event,
-    rows2dicts,
-)
+from puterbot.events import get_events
+from puterbot.utils import display_event, rows2dicts
 from puterbot.models import Recording
 from puterbot.strategies.base import BaseReplayStrategy
 

--- a/puterbot/strategies/ocr_mixin.py
+++ b/puterbot/strategies/ocr_mixin.py
@@ -1,0 +1,161 @@
+"""
+Implements a ReplayStrategy mixin for getting text from images via OCR
+"""
+
+import itertools
+
+from loguru import logger
+from PIL import Image
+from rapidocr_onnxruntime import RapidOCR
+from sklearn.cluster import DBSCAN
+import mss.base
+import numpy as np
+import pandas as pd
+
+from puterbot.models import Recording
+from puterbot.strategies.base import BaseReplayStrategy
+
+
+# TODO: use group into sections via layout analysis; see:
+# https://github.com/RapidAI/RapidOCR/blob/main/python/rapid_structure/docs/README_Layout.md
+
+
+class OCRReplayStrategyMixin(BaseReplayStrategy):
+    def __init__(
+        self,
+        recording: Recording,
+    ):
+        super().__init__(recording)
+
+        # https://github.com/RapidAI/RapidOCR/blob/main/python/README.md
+        self.ocr = RapidOCR()
+
+    def get_text(self, screenshot: mss.base.ScreenShot):
+        image = Image.frombytes(
+            "RGB", screenshot.size, screenshot.bgra, "raw", "BGRX"
+        )
+        arr = np.array(image)
+        result, elapse = self.ocr(arr)
+        #det_elapse, cls_elapse, rec_elapse = elapse
+        #all_elapse = det_elapse + cls_elapse + rec_elapse
+        logger.debug(f"{result=}")
+        logger.debug(f"{elapse=}")
+        df = get_df(result)
+        text = convert_dataframe_to_string(df)
+        return text
+
+
+def unnest(df, explode, axis, suffixes=None):
+    # https://stackoverflow.com/a/53218939
+    if axis == 1:
+        df1 = pd.concat([df[x].explode() for x in explode], axis=1)
+        return df1.join(df.drop(explode, axis=1), how="left")
+    else:
+        df1 = pd.concat(
+            [
+                pd.DataFrame(
+                    df[x].tolist(),
+                    index=df.index,
+                    columns=suffixes,
+                ).add_prefix(x)
+                for x in explode
+            ],
+            axis=1,
+        )
+        return df1.join(
+            df.drop(explode, axis=1),
+            how="left",
+        )
+
+
+def get_df(result):
+	"""
+	Convert RapidOCR result to DataFrame.
+
+	Args:
+		result: list of [coordinates, text, confidence], where
+			coordinates is itself a list of:
+				[tl_x, tl_y],
+				[tr_x, tr_y],
+				[br_x, br_y],
+				[bl_x, bl_y]
+
+	Returns:
+		pd.DataFrame
+	"""
+
+	coords = [coords for coords, text, confidence in result]
+	columns = ["tl", "tr", "bl", "br"]
+	df = pd.DataFrame(coords, columns=columns)
+	df = unnest(df, df.columns, 0, suffixes=["_x", "_y"])
+
+	texts = [text for coords, text, confidence in result]
+	df["text"] = texts
+
+	confidences = [confidence for coords, text, confidence in result]
+	df["confidence"] = confidences
+	logger.info(f"df=\n{df}")
+	return df
+
+
+def preprocess_text(text):
+    return text.strip()
+
+
+def calculate_centroid(row):
+    x = (row["tl_x"] + row["tr_x"] + row["bl_x"] + row["br_x"]) / 4
+    y = (row["tl_y"] + row["tr_y"] + row["bl_y"] + row["br_y"]) / 4
+    return x, y
+
+
+def calculate_height(row):
+    return abs(row["tl_y"] - row["bl_y"])
+
+
+def sort_rows(df):
+    df["centroid"] = df.apply(calculate_centroid, axis=1)
+    df["x"] = df["centroid"].apply(lambda coord: coord[0])
+    df["y"] = df["centroid"].apply(lambda coord: coord[1])
+    df.sort_values(by=["y", "x"], inplace=True)
+    return df
+
+
+def cluster_lines(df, eps):
+    coords = df[["x", "y"]].to_numpy()
+    cluster_model = DBSCAN(eps=eps, min_samples=1)
+    df["line_cluster"] = cluster_model.fit_predict(coords)
+    return df
+
+
+def cluster_words(df):
+    line_dfs = []
+    for line_cluster in df["line_cluster"].unique():
+        line_df = df[df["line_cluster"] == line_cluster].copy()
+
+        if len(line_df) > 1:
+            coords = line_df[["x", "y"]].to_numpy()
+            eps = line_df["height"].min()
+            cluster_model = DBSCAN(eps=eps, min_samples=1)
+            line_df["word_cluster"] = cluster_model.fit_predict(coords)
+        else:
+            line_df["word_cluster"] = 0
+
+        line_dfs.append(line_df)
+    return pd.concat(line_dfs)
+
+
+def concat_text(df):
+    df.sort_values(by=["line_cluster", "word_cluster"], inplace=True)
+    lines = df.groupby("line_cluster")["text"].apply(lambda x: " ".join(x))
+    return "\n".join(lines)
+
+
+def convert_dataframe_to_string(df):
+    df["text"] = df["text"].apply(preprocess_text)
+    sorted_df = sort_rows(df)
+    df["height"] = df.apply(calculate_height, axis=1)
+    eps = df["height"].min()
+    line_clustered_df = cluster_lines(sorted_df, eps)
+    word_clustered_df = cluster_words(line_clustered_df)
+    result = concat_text(word_clustered_df)
+    return result

--- a/puterbot/strategies/ocr_mixin.py
+++ b/puterbot/strategies/ocr_mixin.py
@@ -1,5 +1,10 @@
 """
-Implements a ReplayStrategy mixin for getting text from images via OCR
+Implements a ReplayStrategy mixin for getting text from images via OCR.
+
+Usage:
+
+    class MyReplayStrategy(OCRReplayStrategyMixin):
+        ...
 """
 
 import itertools
@@ -17,7 +22,7 @@ from puterbot.strategies.base import BaseReplayStrategy
 
 
 # TODO: use group into sections via layout analysis; see:
-# https://github.com/RapidAI/RapidOCR/blob/main/python/rapid_structure/docs/README_Layout.md
+# github.com/RapidAI/RapidOCR/blob/main/python/rapid_structure/docs/README_Layout.md
 
 
 class OCRReplayStrategyMixin(BaseReplayStrategy):
@@ -27,10 +32,13 @@ class OCRReplayStrategyMixin(BaseReplayStrategy):
     ):
         super().__init__(recording)
 
-        # https://github.com/RapidAI/RapidOCR/blob/main/python/README.md
+        # github.com/RapidAI/RapidOCR/blob/main/python/README.md
         self.ocr = RapidOCR()
 
-    def get_text(self, screenshot: mss.base.ScreenShot):
+    def get_text(
+        self,
+        screenshot: mss.base.ScreenShot
+    ):
         image = Image.frombytes(
             "RGB", screenshot.size, screenshot.bgra, "raw", "BGRX"
         )

--- a/puterbot/strategies/ocr_mixin.py
+++ b/puterbot/strategies/ocr_mixin.py
@@ -39,6 +39,7 @@ class OCRReplayStrategyMixin(BaseReplayStrategy):
         self,
         screenshot: mss.base.ScreenShot
     ):
+        # TOOD: improve performance
         image = Image.frombytes(
             "RGB", screenshot.size, screenshot.bgra, "raw", "BGRX"
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ scipy==1.9.3
 sqlalchemy==1.4.43
 torch==2.0.0
 tqdm==4.64.0
+transformers==4.28.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,9 @@ pyinstaller
 pywin32==306
 git+https://github.com/abrichr/pynput.git
 pytest==7.1.3
+rapidocr-onnxruntime==1.2.3
+scikit-learn==1.2.2
 scipy==1.9.3
 sqlalchemy==1.4.43
+torch==2.0.0
 tqdm==4.64.0


### PR DESCRIPTION
This PR implements Mixins for adding OCR and LLM functionality, as well as a demonstration strategy that uses both.

It also adds a log_fps() function to replay.py.

```
2023-04-18 21:07:12.996 | INFO     | puterbot.strategies.base:log_fps:66 - fps=0.15
```

Edit: using GPT-2 instead of GPT-2-XL results in ~1fps.

Usage:

```
$ python puterbot/replay.py LLMOCRDemoReplayStrategy
```